### PR TITLE
Fixes for date number

### DIFF
--- a/moonback.sh
+++ b/moonback.sh
@@ -9,14 +9,14 @@ wdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd $wdir
 
 #get current hour of the year
-num=$(($(date +"%j")*24-24+$(date +"%H")))
+num=$((10#$(date --utc +"%j")*24-24+10#$(date --utc +"%H")))
 #get illumination% from text file I edited down from one found here "https://svs.gsfc.nasa.gov/vis/a000000/a004800/a004874/"
 phase=$(sed "$num q;d" phase.txt)
 #days in moon cycle so far
 age=$(sed "$num q;d" age.txt)
 #caption
 text="Phase: $phase% Days: $age     "
-im="moon.$(($(date +"%j")*24-24+$(date +"%H"))).tif"
+im="moon.$num.tif"
 
 if [ $isbig = true ]
 then


### PR DESCRIPTION
Fixes #1 

- The date formats `%j` and `%H` return 0-padded numbers, for example "001" for Jan. 1 or "09" for 9 am. Bash arithmetic interprets numbers that start with a `0` as octal numbers, though, which can lead to unexpected results. For example, `$((024))` evaluates to `20`, and `$((09))` throws an error since that is not a valid octal number. Adding the `10#` here forces it to evaluate it as a base 10 number, which should give the expected results.
- Adds `--utc` to the `date` calls so that you get the same result no matter your local timezone (and it should match what the Dial-A-Moon expects more accurately).
- Uses the stored `$num` to create the `$im` variable so it doesn't have to get calculated again.

This is a fun idea for a desktop background, thanks for making it!